### PR TITLE
Reworked input and transition actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         pip install esphome
     - name: ESPHome Compile examples
       run: |
+        esphome compile test.yaml
         esphome compile toggle-example.yaml
         esphome compile dimmable-light-example.yaml
         esphome compile dual-switch-cover-example.yaml

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ binary_sensor:
 * **states** (**Required**, list): The list of states that the state machine has.
 
   * **name** (**Required**, string): The name of the state. Must not repeat.
-  * **on_enter** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when entering this state. 
-  * **on_leave** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when leaving this state. It called before `on_enter` of the next state.
+  * **on_enter** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when entering this state. Called after `on_transition` automation and before `after_transition`. 
+  * **on_leave** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when leaving this state. Called after `before_transition` automation and before `on_transition` automation. 
   * **on_set** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when setting this state using `set` action or via `initial_state`. Will not trigger if new state is the same as current state.
 
 * **inputs** (**Required**, list): The list of inputs that the state machine supports with allowed state transitions.
@@ -69,14 +69,27 @@ binary_sensor:
   * **transitions** (**Required**, list): The list of allowed transitions. Short form is `FROM_STATE -> TO_STATE`, or advanced configuration:
     * **from** (**Required**, string): Source state that this input is allowed on.
     * **to** (**Required**, string): Target state that this input transitions to.
-    * **action** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when transition is performed. This action is performed before state's `on_leave` action is called.
-  * **action** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when transition is done by this input. This action is performed after transition-specific action and before state's `on_leave` action is called.
+    * **before_transition** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform before transition. Called after `on_input` automation and before `on_transition` automation. 
+    * **on_transition** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform on transition. Called after `on_leave` automation and before `on_enter` automation. 
+    * **after_transition** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform after transition. Called after `on_enter` automation. 
+  * **on_input** (*Optional*, [Automation](https://esphome.io/guides/automations.html#automation)): An automation to perform when this input is triggred. This automation is performed first, then `before_transition ` will be called. This automation will not be called if transition is invalid.
 
 * **diagram** (*Optional*, boolean): If true, then a diagram of the state machine will be output to the console during validation/compilation of YAML. See **Diagrams** section below for more details. Defaults to `false`.
 
 > ### Note:
 >
 > Any running state machine automations (state, input and transition) will be stopped before running next automations. This is useful when there's a delayed transition in one of the automation and it needs to be cancelled because a new input was provided which results in a different transition. 
+
+## Order of Triggers
+
+When State Machine receives input (via `transition` action) it will call the automation specified in the input, transition, the "from" state and the "to" state in the following order:
+
+1. `on_input`
+2. `before_transition`
+3. "From" state `on_leave`
+4. `on_transition`
+5. "To" state `on_enter`
+6. `after_transition`
 
 ## `state_machine.transition` Action
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ When State Machine receives input (via `transition` action) it will call the aut
 5. "To" state `on_enter`
 6. `after_transition`
 
+See [test.yaml](test.yaml) for a demonstration of running order of these automations within a context of simple ON-OFF state machine.
+
 ## `state_machine.transition` Action
 
 You can provide input to the state machine from elsewhere in your WAML file with the `state_machine.transition` action.

--- a/components/state_machine/automation.h
+++ b/components/state_machine/automation.h
@@ -26,16 +26,32 @@ namespace esphome
       }
     };
 
-    class StateMachineOnEnterTrigger : public Trigger<>
+    class StateMachineOnInputTrigger : public Trigger<>
     {
     public:
-      StateMachineOnEnterTrigger(StateMachineComponent *state_machine, std::string state)
+      StateMachineOnInputTrigger(StateMachineComponent *state_machine, std::string input)
       {
-        state_machine->add_on_transition_callback(
-            [this, state](StateTransition transition)
+        state_machine->add_before_transition_callback(
+            [this, input](StateTransition transition)
             {
               this->stop_action(); // stop any previous running actions
-              if (transition.to_state == state)
+              if (transition.input == input)
+              {
+                this->trigger();
+              }
+            });
+      }
+    };
+    class StateMachineBeforeTransitionTrigger : public Trigger<>
+    {
+    public:
+      StateMachineBeforeTransitionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
+      {
+        state_machine->add_before_transition_callback(
+            [this, for_transition](StateTransition transition)
+            {
+              this->stop_action(); // stop any previous running actions
+              if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
               {
                 this->trigger();
               }
@@ -48,7 +64,7 @@ namespace esphome
     public:
       StateMachineOnLeaveTrigger(StateMachineComponent *state_machine, std::string state)
       {
-        state_machine->add_on_transition_callback(
+        state_machine->add_before_transition_callback(
             [this, state](StateTransition transition)
             {
               this->stop_action(); // stop any previous running actions
@@ -59,13 +75,12 @@ namespace esphome
             });
       }
     };
-
-    class StateMachineTransitionActionTrigger : public Trigger<>
+    class StateMachineOnTransitionTrigger : public Trigger<>
     {
     public:
-      StateMachineTransitionActionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
+      StateMachineOnTransitionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
       {
-        state_machine->add_on_transition_callback(
+        state_machine->add_before_transition_callback(
             [this, for_transition](StateTransition transition)
             {
               this->stop_action(); // stop any previous running actions
@@ -77,16 +92,32 @@ namespace esphome
       }
     };
 
-    class StateMachineInputActionTrigger : public Trigger<>
+    class StateMachineOnEnterTrigger : public Trigger<>
     {
     public:
-      StateMachineInputActionTrigger(StateMachineComponent *state_machine, std::string input)
+      StateMachineOnEnterTrigger(StateMachineComponent *state_machine, std::string state)
       {
-        state_machine->add_on_transition_callback(
-            [this, input](StateTransition transition)
+        state_machine->add_after_transition_callback(
+            [this, state](StateTransition transition)
             {
               this->stop_action(); // stop any previous running actions
-              if (transition.input == input)
+              if (transition.to_state == state)
+              {
+                this->trigger();
+              }
+            });
+      }
+    };
+    class StateMachineAfterTransitionTrigger : public Trigger<>
+    {
+    public:
+      StateMachineAfterTransitionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
+      {
+        state_machine->add_after_transition_callback(
+            [this, for_transition](StateTransition transition)
+            {
+              this->stop_action(); // stop any previous running actions
+              if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
               {
                 this->trigger();
               }

--- a/components/state_machine/state_machine.cpp
+++ b/components/state_machine/state_machine.cpp
@@ -96,10 +96,11 @@ namespace esphome
       optional<StateTransition> transition = this->get_transition(input);
       if (transition)
       {
+        this->before_transition_callback_.call(transition.value());
         ESP_LOGD(TAG, "%s: transitioned from %s to %s", input.c_str(), transition.value().from_state.c_str(), transition.value().to_state.c_str());
         this->last_transition_ = transition;
         this->current_state_ = transition.value().to_state;
-        this->transition_callback_.call(transition.value());
+        this->after_transition_callback_.call(transition.value());
       }
       else
       {

--- a/components/state_machine/state_machine.h
+++ b/components/state_machine/state_machine.h
@@ -36,7 +36,8 @@ namespace esphome
       optional<StateTransition> transition(std::string input);
 
       void add_on_set_callback(std::function<void(std::string)> &&callback) { this->set_callback_.add(std::move(callback)); }
-      void add_on_transition_callback(std::function<void(StateTransition)> &&callback) { this->transition_callback_.add(std::move(callback)); }
+      void add_before_transition_callback(std::function<void(StateTransition)> &&callback) { this->before_transition_callback_.add(std::move(callback)); }
+      void add_after_transition_callback(std::function<void(StateTransition)> &&callback) { this->after_transition_callback_.add(std::move(callback)); }
 
     protected:
       std::string name_;
@@ -50,7 +51,8 @@ namespace esphome
       optional<StateTransition> get_transition(std::string input);
 
       CallbackManager<void(std::string)> set_callback_{};
-      CallbackManager<void(StateTransition)> transition_callback_{};
+      CallbackManager<void(StateTransition)> before_transition_callback_{};
+      CallbackManager<void(StateTransition)> after_transition_callback_{};
     };
 
   } // namespace state_machine

--- a/components/state_machine/text_sensor/state_machine_text_sensor.cpp
+++ b/components/state_machine/text_sensor/state_machine_text_sensor.cpp
@@ -10,7 +10,7 @@ namespace esphome
     void StateMachineTextSensor::set_state_machine(StateMachineComponent *state_machine)
     {
       this->state_machine_ = state_machine;
-      this->state_machine_->add_on_transition_callback(
+      this->state_machine_->add_after_transition_callback(
             [this](StateTransition transition)
             {
               this->update();

--- a/dimmable-light-example.yaml
+++ b/dimmable-light-example.yaml
@@ -27,7 +27,7 @@ state_machine:
           - OFF -> ON
           - from: EDITING
             to: EDITING
-            action: # cycle through brightness levels
+            on_transition: # cycle through brightness levels
               - lambda: |-
                   auto call = id(light1).turn_on();
                   auto brightness = id(light1).current_values.get_brightness();
@@ -41,7 +41,7 @@ state_machine:
         transitions:
           - from: "ON"
             to: EDITING
-            action: # single flash to indicate beginning of editing
+            on_transition: # single flash to indicate beginning of editing
               - light.turn_on:
                   id: light1
                   effect: Strobe
@@ -52,7 +52,7 @@ state_machine:
                   transition_length: 100ms
           - from: EDITING
             to: "ON"
-            action: # tripple flash to indicate end of editing
+            on_transition: # tripple flash to indicate end of editing
               - light.turn_on:
                   id: light1
                   effect: Strobe

--- a/test.yaml
+++ b/test.yaml
@@ -33,8 +33,6 @@ state_machine:
         transitions:
           - from: "ON"
             to: "OFF"
-            # action:
-            #   - logger.log: "Turning off"
             before_transition:
               - logger.log: "2. [ON->OFF] before_transition. [ON] on_leave should be called next"
             on_transition:
@@ -49,8 +47,6 @@ state_machine:
               - logger.log: "4. [OFF->ON] on_transition. [ON] on_enter should be called next"
             after_transition:
               - logger.log: "6. [OFF->ON] after_transition. done"
-        # action:
-        #   - logger.log: "Toggling"
         on_input:
           - logger.log: "1. on_input. before_transition should be called next"
     diagram: mermaid

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,75 @@
+esphome:
+  name: test
+  platform: ESP8266
+  board: d1_mini
+
+logger:
+  level: DEBUG
+
+external_components:
+  - source: components
+
+text_sensor:
+  - platform: state_machine
+    name: On/Off Toggle State Machine
+
+state_machine:
+  - name: On/Off Toggle State Machine
+    states:
+      - name: "OFF"
+        on_enter:
+          - output.turn_off: led1
+          - logger.log: "5. [OFF] on_enter. [ON->OFF] after_transition should be called next"
+        on_leave:
+          - logger.log: "3. [OFF] on_leave. [OFF->ON] on_transition should be called next"
+      - name: "ON"
+        on_enter:
+          - output.turn_on: led1
+          - logger.log: "5. [ON] on_enter. [OFF->ON] after_transition should be called next"
+        on_leave:
+          - logger.log: "3. [ON] on_leave. [ON->OFF] on_transition should be called next"
+    inputs:
+      - name: TOGGLE
+        transitions:
+          - from: "ON"
+            to: "OFF"
+            # action:
+            #   - logger.log: "Turning off"
+            before_transition:
+              - logger.log: "2. [ON->OFF] before_transition. [ON] on_leave should be called next"
+            on_transition:
+              - logger.log: "4. [ON->OFF] on_transition. [OFF] on_enter should be called next"
+            after_transition:
+              - logger.log: "6. [ON->OFF] after_transition. done"
+          - from: "OFF"
+            to: "ON"
+            before_transition:
+              - logger.log: "2. [OFF->ON] before_transition. [OFF] on_leave should be called next"
+            on_transition:
+              - logger.log: "4. [OFF->ON] on_transition. [ON] on_enter should be called next"
+            after_transition:
+              - logger.log: "6. [OFF->ON] after_transition. done"
+        # action:
+        #   - logger.log: "Toggling"
+        on_input:
+          - logger.log: "1. on_input. before_transition should be called next"
+    diagram: mermaid
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: D6
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "Button"
+    filters:
+      - delayed_on: 100ms
+    on_press:
+      - state_machine.transition: TOGGLE
+
+output:
+  - platform: gpio
+    pin:
+      number: D4
+      inverted: True
+    id: led1


### PR DESCRIPTION
These changes are to make transition callbacks a bit more flexible and have a better order of execution. Addresses https://github.com/muxa/esphome-state-machine/issues/16 