### PR TITLE
1.0.0-rc.15

### DIFF
--- a/components/state_machine/__init__.py
+++ b/components/state_machine/__init__.py
@@ -383,8 +383,6 @@ async def to_code(config):
 
     await cg.register_component(var, config)
 
-    cg.add(var.dump_config())
-
 @automation.register_action(
     "state_machine.set",
     StateMachineSetAction,

--- a/components/state_machine/automation.h
+++ b/components/state_machine/automation.h
@@ -12,10 +12,10 @@ namespace esphome
     class StateMachineOnSetTrigger : public Trigger<>
     {
     public:
-      StateMachineOnSetTrigger(StateMachineComponent *state_machine, std::string state)
+      StateMachineOnSetTrigger(StateMachineComponent *state_machine, const std::string &state)
       {
         state_machine->add_on_set_callback(
-            [this, state](std::string new_state)
+            [this, state](const std::string &new_state)
             {
               if (new_state == state)
               {
@@ -29,10 +29,10 @@ namespace esphome
     class StateMachineOnInputTrigger : public Trigger<>
     {
     public:
-      StateMachineOnInputTrigger(StateMachineComponent *state_machine, std::string input)
+      StateMachineOnInputTrigger(StateMachineComponent *state_machine, const std::string &input)
       {
         state_machine->add_before_transition_callback(
-            [this, input](StateTransition transition)
+            [this, input](const StateTransition &transition)
             {
               this->stop_action(); // stop any previous running actions
               if (transition.input == input)
@@ -45,10 +45,10 @@ namespace esphome
     class StateMachineBeforeTransitionTrigger : public Trigger<>
     {
     public:
-      StateMachineBeforeTransitionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
+      StateMachineBeforeTransitionTrigger(StateMachineComponent *state_machine, const StateTransition &for_transition)
       {
         state_machine->add_before_transition_callback(
-            [this, for_transition](StateTransition transition)
+            [this, for_transition](const StateTransition &transition)
             {
               this->stop_action(); // stop any previous running actions
               if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
@@ -62,10 +62,10 @@ namespace esphome
     class StateMachineOnLeaveTrigger : public Trigger<>
     {
     public:
-      StateMachineOnLeaveTrigger(StateMachineComponent *state_machine, std::string state)
+      StateMachineOnLeaveTrigger(StateMachineComponent *state_machine, const std::string &state)
       {
         state_machine->add_before_transition_callback(
-            [this, state](StateTransition transition)
+            [this, state](const StateTransition &transition)
             {
               this->stop_action(); // stop any previous running actions
               if (transition.from_state == state)
@@ -78,10 +78,10 @@ namespace esphome
     class StateMachineOnTransitionTrigger : public Trigger<>
     {
     public:
-      StateMachineOnTransitionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
+      StateMachineOnTransitionTrigger(StateMachineComponent *state_machine, const StateTransition &for_transition)
       {
         state_machine->add_before_transition_callback(
-            [this, for_transition](StateTransition transition)
+            [this, for_transition](const StateTransition &transition)
             {
               this->stop_action(); // stop any previous running actions
               if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
@@ -95,10 +95,10 @@ namespace esphome
     class StateMachineOnEnterTrigger : public Trigger<>
     {
     public:
-      StateMachineOnEnterTrigger(StateMachineComponent *state_machine, std::string state)
+      StateMachineOnEnterTrigger(StateMachineComponent *state_machine, const std::string &state)
       {
         state_machine->add_after_transition_callback(
-            [this, state](StateTransition transition)
+            [this, state](const StateTransition &transition)
             {
               this->stop_action(); // stop any previous running actions
               if (transition.to_state == state)
@@ -111,10 +111,10 @@ namespace esphome
     class StateMachineAfterTransitionTrigger : public Trigger<>
     {
     public:
-      StateMachineAfterTransitionTrigger(StateMachineComponent *state_machine, StateTransition for_transition)
+      StateMachineAfterTransitionTrigger(StateMachineComponent *state_machine, const StateTransition &for_transition)
       {
         state_machine->add_after_transition_callback(
-            [this, for_transition](StateTransition transition)
+            [this, for_transition](const StateTransition &transition)
             {
               this->stop_action(); // stop any previous running actions
               if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)

--- a/components/state_machine/state_machine.cpp
+++ b/components/state_machine/state_machine.cpp
@@ -9,10 +9,10 @@ namespace esphome
     static const char *const TAG = "state_machine";
 
     StateMachineComponent::StateMachineComponent(
-        std::vector<std::string> states,
-        std::vector<std::string> inputs,
-        std::vector<StateTransition> transitions,
-        std::string initial_state)
+        const std::vector<std::string> &states,
+        const std::vector<std::string> &inputs,
+        const std::vector<StateTransition> &transitions,
+        const std::string &initial_state)
     {
       this->states_ = states;
       this->inputs_ = inputs;
@@ -59,7 +59,7 @@ namespace esphome
       }
     }
 
-    optional<StateTransition> StateMachineComponent::get_transition(std::string input)
+    optional<StateTransition> StateMachineComponent::get_transition(const std::string &input)
     {
       if (std::find(this->inputs_.begin(), this->inputs_.end(), input) == this->inputs_.end())
       {
@@ -76,7 +76,7 @@ namespace esphome
       return {};
     }
 
-    void StateMachineComponent::set(std::string state)
+    void StateMachineComponent::set(const std::string &state)
     {
       if (std::find(this->states_.begin(), this->states_.end(), state) == this->states_.end())
       {
@@ -92,7 +92,7 @@ namespace esphome
       }
     }
 
-    optional<StateTransition> StateMachineComponent::transition(std::string input)
+    optional<StateTransition> StateMachineComponent::transition(const std::string &input)
     {
       optional<StateTransition> transition = this->get_transition(input);
       if (transition)

--- a/components/state_machine/state_machine.cpp
+++ b/components/state_machine/state_machine.cpp
@@ -8,15 +8,8 @@ namespace esphome
 
     static const char *const TAG = "state_machine";
 
-    StateMachineComponent::StateMachineComponent(
-        const std::vector<std::string> &states,
-        const std::vector<std::string> &inputs,
-        const std::vector<StateTransition> &transitions,
-        const std::string &initial_state)
+    StateMachineComponent::StateMachineComponent(const std::string &initial_state)
     {
-      this->states_ = states;
-      this->inputs_ = inputs;
-      this->transitions_ = transitions;
       this->current_state_ = initial_state;
       this->last_transition_ = {};
     }

--- a/components/state_machine/state_machine.h
+++ b/components/state_machine/state_machine.h
@@ -18,10 +18,10 @@ namespace esphome
     {
     public:
       StateMachineComponent(
-          std::vector<std::string> states,
-          std::vector<std::string> inputs,
-          std::vector<StateTransition> transitions,
-          std::string initial_state);
+          const std::vector<std::string> &states,
+          const std::vector<std::string> &inputs,
+          const std::vector<StateTransition> &transitions,
+          const std::string &initial_state);
 
       const std::string &get_name() const;
       void set_name(const std::string &name);
@@ -32,8 +32,8 @@ namespace esphome
       std::string current_state() { return this->current_state_; }
       optional<StateTransition> last_transition() { return this->last_transition_; }
 
-      void set(std::string state);
-      optional<StateTransition> transition(std::string input);
+      void set(const std::string &state);
+      optional<StateTransition> transition(const std::string &input);
 
       void add_on_set_callback(std::function<void(std::string)> &&callback) { this->set_callback_.add(std::move(callback)); }
       void add_before_transition_callback(std::function<void(StateTransition)> &&callback) { this->before_transition_callback_.add(std::move(callback)); }
@@ -48,7 +48,7 @@ namespace esphome
       std::string current_state_;
       optional<StateTransition> last_transition_;
 
-      optional<StateTransition> get_transition(std::string input);
+      optional<StateTransition> get_transition(const std::string &input);
 
       CallbackManager<void(std::string)> set_callback_{};
       CallbackManager<void(StateTransition)> before_transition_callback_{};

--- a/components/state_machine/state_machine.h
+++ b/components/state_machine/state_machine.h
@@ -31,9 +31,9 @@ namespace esphome
       void set(const std::string &state);
       optional<StateTransition> transition(const std::string &input);
 
-      void add_on_set_callback(std::function<void(std::string)> &&callback) { this->set_callback_.add(std::move(callback)); }
-      void add_before_transition_callback(std::function<void(StateTransition)> &&callback) { this->before_transition_callback_.add(std::move(callback)); }
-      void add_after_transition_callback(std::function<void(StateTransition)> &&callback) { this->after_transition_callback_.add(std::move(callback)); }
+      void add_on_set_callback(std::function<void(const std::string&)> &&callback) { this->set_callback_.add(std::move(callback)); }
+      void add_before_transition_callback(std::function<void(const StateTransition&)> &&callback) { this->before_transition_callback_.add(std::move(callback)); }
+      void add_after_transition_callback(std::function<void(const StateTransition&)> &&callback) { this->after_transition_callback_.add(std::move(callback)); }
 
       void add_state(const std::string &state) {
         this->states_.push_back(state);

--- a/components/state_machine/state_machine.h
+++ b/components/state_machine/state_machine.h
@@ -17,11 +17,7 @@ namespace esphome
     class StateMachineComponent : public Component
     {
     public:
-      StateMachineComponent(
-          const std::vector<std::string> &states,
-          const std::vector<std::string> &inputs,
-          const std::vector<StateTransition> &transitions,
-          const std::string &initial_state);
+      StateMachineComponent(const std::string &initial_state);
 
       const std::string &get_name() const;
       void set_name(const std::string &name);
@@ -38,6 +34,18 @@ namespace esphome
       void add_on_set_callback(std::function<void(std::string)> &&callback) { this->set_callback_.add(std::move(callback)); }
       void add_before_transition_callback(std::function<void(StateTransition)> &&callback) { this->before_transition_callback_.add(std::move(callback)); }
       void add_after_transition_callback(std::function<void(StateTransition)> &&callback) { this->after_transition_callback_.add(std::move(callback)); }
+
+      void add_state(const std::string &state) {
+        this->states_.push_back(state);
+      }
+
+      void add_input(const std::string &input) {
+        this->inputs_.push_back(input);
+      }
+
+      void add_transition(const StateTransition &transition) {
+        this->transitions_.push_back(transition);
+      }
 
     protected:
       std::string name_;


### PR DESCRIPTION
Fixed #29 (crash when using a long list of state and/or transitions)