### PR TITLE
1.0.0-rc.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/components/state_machine/__init__.py
+++ b/components/state_machine/__init__.py
@@ -391,6 +391,7 @@ async def to_code(config):
         },
         key=CONF_STATE
     ),
+    synchronous=True,
 )
 def state_machine_set_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, config[CONF_STATE])
@@ -407,6 +408,7 @@ def state_machine_set_to_code(config, action_id, template_arg, args):
         },
         key=CONF_TRANSITION_INPUT_KEY
     ),
+    synchronous=True,
 )
 def state_machine_transition_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, config[CONF_TRANSITION_INPUT_KEY])

--- a/test.yaml
+++ b/test.yaml
@@ -12,10 +12,10 @@ external_components:
 
 text_sensor:
   - platform: state_machine
-    name: On/Off Toggle State Machine
+    name: On-Off Toggle State Machine
 
 state_machine:
-  - name: On/Off Toggle State Machine
+  - name: On-Off Toggle State Machine
     states:
       - name: "OFF"
         on_enter:

--- a/toggle-example.yaml
+++ b/toggle-example.yaml
@@ -12,10 +12,10 @@ external_components:
 
 text_sensor:
   - platform: state_machine
-    name: On/Off Toggle State Machine
+    name: On-Off Toggle State Machine
 
 state_machine:
-  - name: On/Off Toggle State Machine
+  - name: On-Off Toggle State Machine
     states:
       - name: "OFF"
         on_enter:


### PR DESCRIPTION
Add synchronous parameter to state machine code generation functions
- clears the "missing the synchronous= parameter" warning in ESPHome 2026.03

Update test files to fix warning:
- 'On/Off Toggle State Machine' contains '/' which is reserved as a URL path separator.

Using Python 3.12 for CI
