### PR TITLE
 add multi-source states and identity transitions and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        example:
+          - test.yaml
+          - test-dense-syntax.yaml
+          - toggle-example.yaml
+          - dimmable-light-example.yaml
+          - dual-switch-cover-example.yaml
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.12
@@ -28,9 +37,5 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install esphome
-    - name: ESPHome Compile examples
-      run: |
-        esphome compile test.yaml
-        esphome compile toggle-example.yaml
-        esphome compile dimmable-light-example.yaml
-        esphome compile dual-switch-cover-example.yaml
+    - name: ESPHome Compile ${{ matrix.example }}
+      run: esphome compile ${{ matrix.example }}

--- a/components/state_machine/__init__.py
+++ b/components/state_machine/__init__.py
@@ -88,11 +88,22 @@ CONF_TRANSITION_TO_KEY = 'to'
 CONF_STATE_MACHINE_ID = 'state_machine_id'
 
 def validate_transition(value):
+    """Validate a single transition entry.
+
+    Supports:
+    - Comma-separated source states: ``a,b -> c`` (expands to two transitions)
+    - Empty target for identity transitions: ``a ->`` (stay in same state)
+    Both forms can be combined: ``a,b ->`` means each state stays in itself.
+
+    When the ``from`` field contains commas or the ``to`` field is empty the
+    entry is stored as-is here; the actual expansion into individual
+    ``{from, to}`` dicts is done by :func:`expand_transitions`.
+    """
     if isinstance(value, dict):
         return cv.Schema(
             {
                 cv.Required(CONF_FROM): cv.string_strict,
-                cv.Required(CONF_TO): cv.string_strict,
+                cv.Optional(CONF_TO, default=""): cv.string,
                 cv.Optional(CONF_BEFORE_TRANSITION_KEY): automation.validate_automation(
                     {
                         cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(StateMachineBeforeTransitionTrigger),
@@ -117,6 +128,27 @@ def validate_transition(value):
     a, b = value.split("->", 1)
     a, b = a.strip(), b.strip()
     return validate_transition({CONF_FROM: a, CONF_TO: b})
+
+
+def expand_transitions(transitions):
+    """Expand multi-source and identity transitions into individual dicts.
+
+    ``a,b -> c``  becomes  ``[{from: a, to: c}, {from: b, to: c}]``
+    ``a ->``       becomes  ``[{from: a, to: a}]``  (identity)
+    ``a,b ->``    becomes  ``[{from: a, to: a}, {from: b, to: b}]``
+    """
+    result = []
+    for transition in transitions:
+        sources = [s.strip() for s in transition[CONF_FROM].split(",") if s.strip()]
+        if not sources:
+            raise cv.Invalid("Transition 'from' must not be empty")
+        target = transition[CONF_TO]  # may be empty string = identity
+        # Carry over any automation keys (before_transition, on_transition, after_transition)
+        extra = {k: v for k, v in transition.items() if k not in (CONF_FROM, CONF_TO)}
+        for src in sources:
+            effective_to = target if target else src  # empty target → identity
+            result.append({CONF_FROM: src, CONF_TO: effective_to, **extra})
+    return result
 
 def output_graph(config):
     if not CONF_DIAGRAM in config:
@@ -180,6 +212,7 @@ def validate_transitions(config):
 
     return config
 
+
 def unique_names(items): 
     names = list(map(lambda x: x[CONF_NAME], items));
     if len(names) != len(set(names)):
@@ -227,7 +260,7 @@ CONFIG_SCHEMA = cv.All(
                         ),
                         cv.Optional(CONF_INPUT_ACTION_KEY): cv.invalid("`action` is deprecated. Please use `on_input` instead"),
                         cv.Optional(CONF_INPUT_TRANSITIONS_KEY): cv.All(
-                            cv.ensure_list(validate_transition), cv.Length(min=1)
+                            cv.ensure_list(validate_transition), expand_transitions, cv.Length(min=1)
                         ),
                     },
                     key=CONF_NAME

--- a/components/state_machine/automation.h
+++ b/components/state_machine/automation.h
@@ -34,9 +34,9 @@ namespace esphome
         state_machine->add_before_transition_callback(
             [this, input](const StateTransition &transition)
             {
-              this->stop_action(); // stop any previous running actions
               if (transition.input == input)
               {
+                this->stop_action(); // stop any previous running actions
                 this->trigger();
               }
             });
@@ -50,9 +50,9 @@ namespace esphome
         state_machine->add_before_transition_callback(
             [this, for_transition](const StateTransition &transition)
             {
-              this->stop_action(); // stop any previous running actions
               if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
               {
+                this->stop_action(); // stop any previous running actions
                 this->trigger();
               }
             });
@@ -67,9 +67,13 @@ namespace esphome
         state_machine->add_before_transition_callback(
             [this, state](const StateTransition &transition)
             {
-              this->stop_action(); // stop any previous running actions
-              if (transition.from_state == state)
+              if (transition.to_state == state && transition.from_state != transition.to_state)
               {
+                this->stop_action(); // stop if we enter the state
+              }
+              if (transition.from_state != transition.to_state && transition.from_state == state)
+              {
+                this->stop_action(); // stop any previous running actions
                 this->trigger();
               }
             });
@@ -83,9 +87,9 @@ namespace esphome
         state_machine->add_before_transition_callback(
             [this, for_transition](const StateTransition &transition)
             {
-              this->stop_action(); // stop any previous running actions
               if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
               {
+                this->stop_action(); // stop any previous running actions
                 this->trigger();
               }
             });
@@ -100,9 +104,13 @@ namespace esphome
         state_machine->add_after_transition_callback(
             [this, state](const StateTransition &transition)
             {
-              this->stop_action(); // stop any previous running actions
-              if (transition.to_state == state)
+              if (transition.from_state == state && transition.from_state != transition.to_state)
               {
+                this->stop_action(); // stop if we leave the state
+              }
+              if (transition.from_state != transition.to_state && transition.to_state == state)
+              {
+                this->stop_action(); // stop any previous running actions
                 this->trigger();
               }
             });
@@ -116,9 +124,9 @@ namespace esphome
         state_machine->add_after_transition_callback(
             [this, for_transition](const StateTransition &transition)
             {
-              this->stop_action(); // stop any previous running actions
               if (transition.from_state == for_transition.from_state && transition.input == for_transition.input && transition.to_state == for_transition.to_state)
               {
+                this->stop_action(); // stop any previous running actions
                 this->trigger();
               }
             });

--- a/test-dense-syntax.yaml
+++ b/test-dense-syntax.yaml
@@ -1,0 +1,137 @@
+esphome:
+  name: test-dense-syntax
+
+esp8266:
+  board: d1_mini
+
+logger:
+  level: DEBUG
+
+external_components:
+  - source: components
+
+# ---------------------------------------------------------------------------
+# Test state machine: 3-state traffic-light style machine
+#
+#   States: RED, YELLOW, GREEN
+#
+#   Inputs and transitions (using new shorthand syntax):
+#
+#   ADVANCE     RED -> GREEN     (normal)
+#               GREEN -> YELLOW  (normal)
+#               YELLOW -> RED    (normal)
+#
+#   RESET       GREEN,YELLOW ->  RED  (multi-source: both go to RED)
+#
+#   PAUSE       GREEN,YELLOW ->      (identity: each stays in its own state)
+#               RED ->               (identity: stay in RED)
+#
+# ---------------------------------------------------------------------------
+
+text_sensor:
+  - platform: state_machine
+    name: Traffic Light State Machine
+
+state_machine:
+  - name: Traffic Light State Machine
+    states:
+      - name: "RED"
+        on_enter:
+          - logger.log: "[RED] entered"
+        on_leave:
+          - logger.log: "[RED] leaving"
+
+      - name: "YELLOW"
+        on_enter:
+          - logger.log: "[YELLOW] entered"
+        on_leave:
+          - logger.log: "[YELLOW] leaving"
+
+      - name: "GREEN"
+        on_enter:
+          - logger.log: "[GREEN] entered"
+        on_leave:
+          - logger.log: "[GREEN] leaving"
+
+    inputs:
+      # -----------------------------------------------------------------------
+      # ADVANCE: step through RED -> GREEN -> YELLOW -> RED using plain syntax
+      # -----------------------------------------------------------------------
+      - name: ADVANCE
+        transitions:
+          - "RED -> GREEN"
+          - "GREEN -> YELLOW"
+          - "YELLOW -> RED"
+        on_input:
+          - logger.log: "ADVANCE input received"
+
+      # -----------------------------------------------------------------------
+      # RESET: multi-source shorthand – from GREEN or YELLOW, go to RED
+      #   expands to:
+      #     GREEN  -> RED
+      #     YELLOW -> RED
+      # -----------------------------------------------------------------------
+      - name: RESET
+        transitions:
+          - "GREEN,YELLOW -> RED"
+        on_input:
+          - logger.log: "RESET input received (GREEN or YELLOW -> RED)"
+
+      # -----------------------------------------------------------------------
+      # PAUSE: identity shorthand – every listed state stays in itself
+      #   "GREEN,YELLOW ->" expands to: GREEN -> GREEN, YELLOW -> YELLOW
+      #   "RED ->"          expands to: RED -> RED
+      # Combined they cover all three states.
+      # -----------------------------------------------------------------------
+      - name: PAUSE
+        transitions:
+          - "GREEN,YELLOW ->"
+          - "RED ->"
+        on_input:
+          - logger.log: "PAUSE input received (identity – state unchanged)"
+
+    diagram: mermaid
+
+# ---------------------------------------------------------------------------
+# Wire three buttons to the three inputs
+# ---------------------------------------------------------------------------
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: D5
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "Advance Button"
+    filters:
+      - delayed_on: 50ms
+    on_press:
+      - state_machine.transition: ADVANCE
+
+  - platform: gpio
+    pin:
+      number: D6
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "Reset Button"
+    filters:
+      - delayed_on: 50ms
+    on_press:
+      - state_machine.transition: RESET
+
+  - platform: gpio
+    pin:
+      number: D7
+      mode: INPUT_PULLUP
+      inverted: True
+    name: "Pause Button"
+    filters:
+      - delayed_on: 50ms
+    on_press:
+      - state_machine.transition: PAUSE
+
+output:
+  - platform: gpio
+    pin:
+      number: D4
+      inverted: True
+    id: led1


### PR DESCRIPTION
## Summary
Adds two new shorthand syntaxes to transition definitions, making state machine configurations more concise and expressive.

## New Syntax
*Multi-source transitions* — list comma-separated source states to share a single target:
```yaml
- "GREEN,YELLOW -> RED"   # equivalent to two separate transitions
```
*Identity transitions* — omit the target state to stay in the current state:
```yaml
- "RED ->"                # RED stays RED
- "GREEN,YELLOW ->"       # GREEN stays GREEN, YELLOW stays YELLOW
```
Both forms can be combined freely with the existing long-hand dict syntax and all automation hooks

## Bonus
CI now runs examples in parallel